### PR TITLE
Fix base code

### DIFF
--- a/src/main/java/de/thm/asc/automata/algorithms/PowersetConstruction.java
+++ b/src/main/java/de/thm/asc/automata/algorithms/PowersetConstruction.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
  * and then creating transitions for every transition for any of the original states in a set to all other relevant subset-states, we can achieve a DFA.
  */
 public class PowersetConstruction {
-    public static FiniteAutomaton apply(FiniteAutomaton nfa) {
+    public static FiniteAutomaton apply(FiniteAutomaton nfa) {    
         return new PowersetConstruction(nfa).construct();
     }
 
@@ -28,19 +28,26 @@ public class PowersetConstruction {
      */
     private Set<State> epsilonClosure(State s) {
         Set<State> result = new HashSet<>();
+        Queue<State> statesToView = new LinkedList<>();
+        Set<State> completedStates = new HashSet<>();
 
         result.add(s);
+        statesToView.add(s);
 
-        Iterator<State> iter = result.iterator(); // this does not work because the set needs to be modified during iteration
+        while (!statesToView.isEmpty()) {
+            State cur = statesToView.remove();
 
-        while (iter.hasNext()) {
-            State cur = iter.next();
             Set<Transition> transitions = nfa.getTransitions(cur);
             transitions.forEach(t -> {
                 if (t.isEpsilonTransition()) {
                     result.add(t.right);
+
+                    if (!completedStates.contains(t.right)) {
+                        statesToView.add(t.right);
+                    }
                 }
             });
+            completedStates.add(cur);
         }
 
         return result;

--- a/src/main/java/de/thm/asc/automata/algorithms/PowersetConstruction.java
+++ b/src/main/java/de/thm/asc/automata/algorithms/PowersetConstruction.java
@@ -78,7 +78,7 @@ public class PowersetConstruction {
         start.forEach(cur -> {
             nfa.getTransitions(cur)
                 .stream()
-                .filter(t -> !t.isEpsilonTransition() && t.symbol.equals(symbol))
+                .filter(t -> !t.isEpsilonTransition() && t.symbol.get().equals(symbol))
                 .map(t -> epsilonClosure(t.right))
                 .forEach(set -> result.addAll(set));
         });
@@ -102,36 +102,40 @@ public class PowersetConstruction {
      * @return The equivalent deterministic finite automaton (DFA).
      */
     private FiniteAutomaton construct() {
-        Set<State> states = new HashSet<>();
-        Set<State> finalStates = new HashSet<>();
+        Queue<Set<State>> supersetsToView = new LinkedList<>();
+        Set<Set<State>> completedSupersets = new HashSet<>();
         Set<Transition> transitions = new HashSet<>();
 
-        Map<Set<State>, State> map = new HashMap<>();
-
         Set<State> initialState = epsilonClosure(nfa.initialState());
-        states.add(setToState(initialState));
-        map.put(initialState, setToState(initialState));
+        supersetsToView.add(initialState);
 
-        Iterator<Set<State>> iter = map.keySet().iterator(); // this does not work because the set needs to be modified during iteration
-        while (iter.hasNext()) {
-            Set<State> cur = iter.next();
+        while (!supersetsToView.isEmpty()) {
+            Set<State> cur = supersetsToView.remove();
 
             nfa.alphabet().forEach(symbol -> {
                 Set<State> ends = epsilonClosure(move(cur, symbol));
-                states.add(setToState(ends));
-                map.put(ends, setToState(ends));
-                if (!Collections.disjoint(nfa.finalStates(), ends)) {
-                    finalStates.add(setToState(ends));
+
+                Transition newTransition = Transition.newSymbolTransition(setToState(cur), setToState(ends), symbol);
+                if (transitions.stream().noneMatch(transition -> transition.left.equals(newTransition.left) && transition.right.equals(newTransition.right) && transition.symbol.equals(newTransition.symbol))) {
+                    transitions.add(newTransition);
                 }
 
-                transitions.add(Transition.newSymbolTransition(setToState(cur), setToState(ends), symbol));
+                if (completedSupersets.stream().noneMatch(superset -> superset.equals(ends))) {
+                    supersetsToView.add(ends);
+                }
             });
+
+            completedSupersets.add(cur);
         }
+
+        Set<State> states = completedSupersets.stream().map(superset -> setToState(superset)).collect(Collectors.toSet());
+        Set<State> originalFinalStates = this.nfa.finalStates();
+        Set<State> finalStates = completedSupersets.stream().filter(superset -> !Collections.disjoint(originalFinalStates, superset)).map(superset -> setToState(superset)).collect(Collectors.toSet());
 
         return new FiniteAutomaton(states, nfa.alphabet(), setToState(initialState), finalStates, transitions);
     }
 
     private State setToState(Set<State> set) {
-        return new State("{" + set.stream().map(state -> state.toString()).collect(Collectors.joining()) + "}");
+        return new State("{" + set.stream().map(state -> state.name()).collect(Collectors.joining()) + "}");
     }
 }


### PR DESCRIPTION
These commits fix the methods required to construct a deterministic automaton. Code is real messy but it works:

Resulting dotcode for input.txt:
```
digraph automata {
    node [shape=doublecircle]; {q4}
    node [shape=point, style=invis]; ENTRY;
    node [shape=circle, style=solid];
    ENTRY -> {q0};
    {q2q3} -> {q4} [label="a"]
    {q4} -> {} [label="b"]
    {} -> {} [label="b"]
    {} -> {} [label="a"]
    {q4} -> {} [label="a"]
    {q2q3} -> {q2q3} [label="b"]
    {q1q2q3} -> {q4} [label="a"]
    {q0} -> {} [label="b"]
    {q0} -> {q1q2q3} [label="a"]
    {q1q2q3} -> {q2q3} [label="b"]
}
```

Resulting image on graphviz:
![graphviz](https://github.com/user-attachments/assets/e0eb6d9b-cf7e-47fd-96bb-6e1f83209ddd)
